### PR TITLE
Fixes spacing in tilesets.

### DIFF
--- a/src/MapLoaderPrivate.cpp
+++ b/src/MapLoaderPrivate.cpp
@@ -222,7 +222,7 @@ bool MapLoader::m_ProcessTiles(const pugi::xml_node& tilesetNode)
 			rect.top += margin;
 			rect.height = tileHeight;
 			rect.left = x * (tileWidth + spacing);
-			rect.left += spacing;
+			rect.left += margin;
 			rect.width = tileWidth;
 
 			//store texture coords and tileset index for vertex array


### PR DESCRIPTION
When using spacing in tilesets, tiles will be off by what ever spacing is set to. Replacing `spacing` by `maring` fixed it for me and by looking at the code I would say, this was intended anyway.

Cheers for sharing your code on Github :+1:
