### PR TITLE
Tile Rotation 

### DIFF
--- a/include/tmx/MapLoader.h
+++ b/include/tmx/MapLoader.h
@@ -149,10 +149,6 @@ namespace tmx
 		std::map<std::string, std::shared_ptr<sf::Image> >m_cachedImages;
 		bool m_failedImage;
 
-        const unsigned FLIPPED_HORIZONTALLY_FLAG = 0x80000000;
-        const unsigned FLIPPED_VERTICALLY_FLAG   = 0x40000000;
-        const unsigned FLIPPED_DIAGONALLY_FLAG   = 0x20000000;
-
         //Reading the flipped bits
         std::vector<unsigned char> m_IntToBytes(sf::Uint32 paramInt);
         std::pair<sf::Uint32, std::bitset<3> > m_ResolveRotation(sf::Uint32 gid);
@@ -163,11 +159,11 @@ namespace tmx
         void m_FlipD(sf::Vector2f *v0, sf::Vector2f *v1, sf::Vector2f *v2, sf::Vector2f *v3);
 
         void m_DoFlips(std::bitset<3> bits,sf::Vector2f *v0, sf::Vector2f *v1, sf::Vector2f *v2, sf::Vector2f *v3);
-	};
+    };
 
 
 	//method for decoding base64 encoded strings
 	static std::string base64_decode(std::string const& string);
-};
+}
 
 #endif //MAP_LOADER_H_

--- a/src/MapLoaderPrivate.cpp
+++ b/src/MapLoaderPrivate.cpp
@@ -411,6 +411,10 @@ std::vector<unsigned char> MapLoader::m_IntToBytes(sf::Uint32 paramInt)
 
 std::pair<sf::Uint32, std::bitset<3> > MapLoader::m_ResolveRotation(sf::Uint32 gid)
 {
+    const unsigned FLIPPED_HORIZONTALLY_FLAG = 0x80000000;
+    const unsigned FLIPPED_VERTICALLY_FLAG   = 0x40000000;
+    const unsigned FLIPPED_DIAGONALLY_FLAG   = 0x20000000;
+
     std::vector<unsigned char> bytes = m_IntToBytes(gid);
     sf::Uint32 tileGID = bytes[0] | bytes[1] << 8 | bytes[2] << 16 | bytes[3] << 24;
 


### PR DESCRIPTION
This recognises the rotation of tiles and resets the GID. I'm not too sure if I've hit every use case here. I haven't tested the flip horizontally and vertically tiles yet, I'll do that later. Also, I think it will require some kind of array to keep track of which tiles are flipped, and in what way. Any input you have about where this can fit in to the interface would be gratefully accepted.
