### PR TITLE
fix for building sfml-tmxloader on MacOSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
+# on MacOSX you need to use the correct stdlib for c++11 features
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
+
 # Make sure that the runtime library gets link statically
 if(TMX_STATIC_STD_LIBS)
 	if(NOT SFML_STATIC_LIBS)

--- a/include/tmx/Helpers.h
+++ b/include/tmx/Helpers.h
@@ -28,7 +28,7 @@ it freely, subject to the following restrictions:
 #ifndef HELPERS_H_
 #define HELPERS_H_
 
-#include <math.h>
+#include <cmath>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/System/Vector2.hpp>
 


### PR DESCRIPTION
While building with C++11 features you need to include the corresponding C++ like header files <c...> instead of old C includes.

Also on MacOSX you need to set the additional -stdlib=libc++ flag for building.