### PR TITLE
fix using '.' as search path

### DIFF
--- a/src/MapLoaderPublic.cpp
+++ b/src/MapLoaderPublic.cpp
@@ -128,6 +128,8 @@ void MapLoader::AddSearchPath(const std::string& path)
 
 	if(s.size() > 1 && *s.rbegin() != '/')
 		s += '/';
+	else if (s == ".")
+		s = "./";
 	else if(s == "/" || s == "\\") s = "";
 }
 


### PR DESCRIPTION
Using '.' as a placeholder for "current directory" is very common. But it doesn't work in the sfml-tmxloader.
So I think this minor change should be made.