### PR TITLE
Fixed compiler warnings

### DIFF
--- a/include/tmx/DebugShape.h
+++ b/include/tmx/DebugShape.h
@@ -44,8 +44,8 @@ public:
 
 private:
 
+  sf::VertexArray m_array;
 	bool m_closed;
-	sf::VertexArray m_array;
 	void draw(sf::RenderTarget& rt, sf::RenderStates states)const;
 
 };

--- a/include/tmx/MapLoader.h
+++ b/include/tmx/MapLoader.h
@@ -173,7 +173,7 @@ namespace tmx
 
 
 	//method for decoding base64 encoded strings
-	static std::string base64_decode(std::string const& string);
+  std::string base64_decode(std::string const& string);
 }
 
 #endif //MAP_LOADER_H_

--- a/src/MapLayer.cpp
+++ b/src/MapLayer.cpp
@@ -58,8 +58,8 @@ LayerSet::LayerSet(const sf::Texture& texture, sf::Uint8 patchSize, const sf::Ve
 	: m_texture	(texture),
 	m_patchSize	(patchSize),
 	m_mapSize	(mapSize),
-	m_tileSize	(tileSize),
 	m_patchCount(std::ceil(static_cast<float>(mapSize.x) / patchSize), std::ceil(static_cast<float>(mapSize.y) / patchSize)),
+	m_tileSize	(tileSize),
 	m_visible	(true)
 {
 	m_patches.resize(m_patchCount.x * m_patchCount.y);
@@ -98,8 +98,8 @@ void LayerSet::Cull(const sf::FloatRect& bounds)
 
 	m_visiblePatchEnd.x = static_cast<int>(std::ceil((bounds.width / m_tileSize.x) / m_patchSize));
 	m_visiblePatchEnd.y = static_cast<int>(std::ceil((bounds.height / m_tileSize.y) / m_patchSize));
-	if(m_visiblePatchEnd.x > m_patchCount.x) m_visiblePatchEnd.x = m_patchCount.x;
-	if(m_visiblePatchEnd.y > m_patchCount.y) m_visiblePatchEnd.y = m_patchCount.y;
+	if(m_visiblePatchEnd.x > static_cast<int>(m_patchCount.x)) m_visiblePatchEnd.x = m_patchCount.x;
+	if(m_visiblePatchEnd.y > static_cast<int>(m_patchCount.y)) m_visiblePatchEnd.y = m_patchCount.y;
 
 	m_visiblePatchEnd += m_visiblePatchStart;
 }

--- a/src/MapLoaderPrivate.cpp
+++ b/src/MapLoaderPrivate.cpp
@@ -343,8 +343,7 @@ bool MapLoader::ProcessTiles(const pugi::xml_node& tilesetNode)
 
 bool MapLoader::ParseCollectionOfImages(const pugi::xml_node& tilesetNode)
 {
-    pugi::xml_node tile;
-    if (tile = tilesetNode.child("tile"))
+    if (pugi::xml_node tile = tilesetNode.child("tile"))
     {
         while (tile)
         {
@@ -602,7 +601,7 @@ void MapLoader::FlipX(sf::Vector2f *v0, sf::Vector2f *v1, sf::Vector2f *v2, sf::
     v3->x = v0->x ;
 }
 
-void MapLoader::FlipD(sf::Vector2f *v0, sf::Vector2f *v1, sf::Vector2f *v2, sf::Vector2f *v3)
+void MapLoader::FlipD(sf::Vector2f * /* v0 */, sf::Vector2f *v1, sf::Vector2f * /* v2 */, sf::Vector2f *v3)
 {
     //Diagonal flip
     sf::Vector2f tmp = *v1;
@@ -816,9 +815,9 @@ bool MapLoader::ParseObjectgroup(const pugi::xml_node& groupNode)
 		}
 		//else parse poly points
         else if (objectNode.find_child(FindByName("polygon")) || objectNode.find_child(FindByName("polyline")))
-		{
+                {
             pugi::xml_node child;
-            if (child = objectNode.find_child(FindByName("polygon")))
+            if ((child = objectNode.find_child(FindByName("polygon"))))
             {
                 object.SetShapeType(Polygon);
             }
@@ -1078,7 +1077,7 @@ std::string MapLoader::FileFromPath(const std::string& path)
 	return path;
 }
 
-void MapLoader::draw(sf::RenderTarget& rt, sf::RenderStates states) const
+void MapLoader::draw(sf::RenderTarget& rt, sf::RenderStates /* states */) const
 {
 	sf::View view  = rt.getView();
 	if(view.getCenter() != m_lastViewPos)
@@ -1192,7 +1191,6 @@ bool MapLoader::Decompress(const char* source, std::vector<unsigned char>& dest,
 	byteArray = std::move(newArray);
 
 	//copy bytes to vector
-	int length = currentSize / sizeof(unsigned char);	
     dest.insert(dest.begin(), byteArray.begin(), byteArray.end());
 
 	return true;
@@ -1273,7 +1271,7 @@ static inline bool is_base64(unsigned char c)
 	return (isalnum(c) || (c == '+') || (c == '/'));
 }
 
-static std::string base64_decode(std::string const& encoded_string)
+std::string base64_decode(std::string const& encoded_string)
 {
 	int in_len = encoded_string.size();
 	int i = 0;

--- a/src/QuadTreeNode.cpp
+++ b/src/QuadTreeNode.cpp
@@ -146,7 +146,7 @@ void QuadTreeNode::GetVertices(std::vector<sf::Vertex>& vertices)
 
 
 //private functions//
-void QuadTreeRoot::draw(sf::RenderTarget& rt, sf::RenderStates states) const
+void QuadTreeRoot::draw(sf::RenderTarget& rt, sf::RenderStates /* states */) const
 {
     std::vector<sf::Vertex> verts;
     for (const auto& c : m_children)

--- a/src/tmx2box2d.cpp
+++ b/src/tmx2box2d.cpp
@@ -221,7 +221,6 @@ BodyCreator::Shapes BodyCreator::m_ProcessConvex(const Shape& points)
 	for (auto i = 0u; i <= shapeCount; i++)
 	{
 		Shape shape;
-		sf::Uint16 total = 0u;
 		for (auto j = 0u; j < maxVerts; j++)
 		{
 			sf::Uint16 index = i * maxVerts + j;


### PR DESCRIPTION
When I compile under GCC under high warning levels ( -Wall -Wextra -Weffc++ ), some warnings pop up. They are -AFAIKS- harmless, but it spoils my clean compile. Things I fixed are unused variables and initialization order. I did not try to be clever, I just fixed the compiler warnings in the simplest way possible.